### PR TITLE
imp: fixed .derpylabel jumpy behavior

### DIFF
--- a/projects_css.css
+++ b/projects_css.css
@@ -4,6 +4,7 @@ body {
 
 .box {
 	background-color: rgba(255,255,255, 0.8) !important;
+	transform: translateZ(0);
 }
 
 .item.box .image {
@@ -12,6 +13,7 @@ body {
 
 .item.box:hover {
 	background-color: rgba(255,255,255, 0.75) !important;
+	transform: scale(1.01);
 	/*margin-top: 10px;
 	margin-bottom: -10px;*/
 }
@@ -33,7 +35,7 @@ body {
 .item.box .derp.label {
     position: absolute;
     height: 23px;
-    left: 0px;
+    left: -14px;
     margin-top: 15px;
     z-index: 2;
 }


### PR DESCRIPTION
Make .item.box, always transform-d with translateZ(0), (no visual change)
That way .item.box is always in its own transform context and we can style derpylabel.
